### PR TITLE
net-passwd.h-example: Add more description

### DIFF
--- a/net-passwd.h-example
+++ b/net-passwd.h-example
@@ -1,4 +1,15 @@
+/* Example for a config file for the MQTT433gateway. Adapt as needed and copy to net-passwd.h
+*/
+
+// The locale Wifi SSID
 #define mySSID "wifissid"
+
+// The Wifi Passphrase
 #define myWIFIPASSWD "wifi_secret"
+
+// IP Address of the MQTT BROCKER
 #define myMQTT_BROCKER "192.168.1.1"
+
+// Password for the OTA update
 #define myOTA_PASSWD "ota_secret"
+


### PR DESCRIPTION
This patch adds some more description to the config file