### PR TITLE
WiFiManager second try

### DIFF
--- a/lib/Heartbeat/HeartbeatFlashing.cpp
+++ b/lib/Heartbeat/HeartbeatFlashing.cpp
@@ -27,30 +27,17 @@
   SOFTWARE.
 */
 
-// This is commented out for now as platformIO finds
-// the CPP file and tries to build an object file, but
-// because the header was not included anywhere the
-// "Ticker" lib will not added to the dependency tree
-// and the buid will hail because Ticker.h was not
-// found.
-// To enable this code, just remove the "#if 0" and
-// include the header HeartbeatFlashing.h somewhere
-// where the PlatformIO Buildsystem can see it.
-#if 0
-
 #include "HeartbeatFlashing.h"
 
-void _flash_tick(LED* led) {
-  led->toggle();
-}
+void _flash_tick(LED* led) { led->toggle(); }
 
 HeartbeatFlashing::HeartbeatFlashing(LED& led, int interval)
-  : Heartbeat(led, interval) {
+    : Heartbeat(led, interval) {
   _flashing = false;
 }
 
 HeartbeatFlashing::HeartbeatFlashing(int pin, int interval)
-  : Heartbeat(pin, interval) {
+    : Heartbeat(pin, interval) {
   _flashing = false;
 }
 
@@ -67,5 +54,3 @@ void HeartbeatFlashing::flash(unsigned int onMilliseconds) {
   _flashing = true;
   _ticker.attach_ms(onMilliseconds, _flash_tick, &_led);
 }
-
-#endif

--- a/lib/Heartbeat/HeartbeatFlashing.h
+++ b/lib/Heartbeat/HeartbeatFlashing.h
@@ -38,7 +38,7 @@ class HeartbeatFlashing : public Heartbeat {
  public:
   HeartbeatFlashing(LED& led, int interval = 100);
   HeartbeatFlashing(int pin, int interval = 100);
-  virtual void off();
+  virtual void off() override;
   void flash(unsigned int onMilliseconds);
 
  protected:

--- a/lib/Heartbeat/library.properties
+++ b/lib/Heartbeat/library.properties
@@ -1,5 +1,5 @@
 name=Heartbeat
-version=0.3.1
+version=0.3.2
 author=Puuu
 maintainer=Puuu <puuu@users.noreply.github.com>
 sentence=Library for flashing LED

--- a/platformio.ini
+++ b/platformio.ini
@@ -14,6 +14,7 @@ framework = arduino
 #board_f_cpu = 160000000L
 build_flags = -Wall
 lib_deps =
+  WiFiManager
   ESP8266WiFi
   ESP8266httpUpdate
   ESP8266HTTPClient

--- a/src/MQTT433gateway.cpp
+++ b/src/MQTT433gateway.cpp
@@ -59,7 +59,7 @@ WiFiClient wifi;
 PubSubClient mqtt(wifi);
 Heartbeat beatLED(HEARTBEAD_LED_PIN);
 ESPiLight rf(TRANSMITTER_PIN);
-SHAauth otaAuth(myOTA_PASSWD);
+SHAauth otaAuth(myADMIN_PASSWD);
 
 const String mainTopic = String("rfESP_") + String(ESP.getChipId(), HEX);
 const String globalTopic = "rf434";

--- a/src/MQTT433gateway.cpp
+++ b/src/MQTT433gateway.cpp
@@ -35,10 +35,9 @@
 #include <ESPiLight.h>
 #include <PubSubClient.h>
 
-#include <Heartbeat.h>
+#include <HeartbeatFlashing.h>
 #include <SHAauth.h>
 #include <debug_helper.h>
-
 
 #ifndef myMQTT_USERNAME
 #define myMQTT_USERNAME nullptr
@@ -57,7 +56,7 @@ const int HEARTBEAD_LED_PIN = 0;
 
 WiFiClient wifi;
 PubSubClient mqtt(wifi);
-Heartbeat beatLED(HEARTBEAD_LED_PIN);
+HeartbeatFlashing beatLED(HEARTBEAD_LED_PIN);
 ESPiLight rf(TRANSMITTER_PIN);
 SHAauth otaAuth(myADMIN_PASSWD);
 

--- a/src/config.h-example
+++ b/src/config.h-example
@@ -4,12 +4,6 @@
 // Debug on or off
 #define DEBUG
 
-// The locale Wifi SSID
-#define mySSID "wifissid"
-
-// The Wifi Passphrase
-#define myWIFIPASSWD "wifi_secret"
-
 // IP Address of the MQTT BROCKER
 #define myMQTT_BROCKER "192.168.1.1"
 

--- a/src/config.h-example
+++ b/src/config.h-example
@@ -17,6 +17,5 @@
 //#define myMQTT_USERNAME "user"
 //#define myMQTT_PASSWORD "pass"
 
-// Password for the OTA update
-#define myOTA_PASSWD "ota_secret"
-
+// Password for the WiFiManager and OTA update
+#define myADMIN_PASSWD "admin_secret"


### PR DESCRIPTION
Here is my alternative implementation of the WiFiManager. I removed the old wifi config parameter, since they are stored in flash and survive an update. The ota password is now the admin password and should be later managed by the Settings module as common administration password (ota, wifimanage, web interface). Now using HeartbeatFlashing for proper status signalling (slow flashing = connecting to wifi, fast flashing = ap mode). 

I am not a big fan of the implementation of the WiFiManager. For example, they do not use streaming but a [long String variable](https://github.com/tzapu/WiFiManager/blob/master/WiFiManager.cpp#L405) to generate and deliver the html data. This buffers everything twice and lead to heap fragmentation. At the end we can run out of memory, if there are many wifi networks.

Also there is no easy way to provide a static ip configuration.