### PR TITLE
Added documented support for the nodemcu platform for NodeMCU 0.9 boards

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ platformio run --environment <board>
 ```
 The available boards are defined in `platformio.ini`. Currently, this are
 + `esp12e` for ESP8266-12e/f models,
-+ `nodemcuv2` for NodeMCU boards,
++ `nodemcu` for NodeMCU 0.9 boards,
++ `nodemcuv2` for NodeMCU 1.0 boards,
 + `d1_mini`for D1 Mini boards,
 + `huzzah` for the Huzzah boards.
 
@@ -272,8 +273,8 @@ Updates of the MQTT433gateway can be preformed by OTA (Over-the-air
 programming).  To do this, the binary file must be provided by HTTP.
 The URL and the authentication information are handled via MQTT.
 
-All this is implemented in the `ota_update.py` Python script.  It will
-start a HTTP server and handle the MQTT communication.  It requires
+All this is implemented in the `ota_update.py` Python 3 script. It will
+start a HTTP server and handle the MQTT communication. It requires
 the Python paho-mqtt module:
 
 ```console

--- a/platformio.ini
+++ b/platformio.ini
@@ -29,6 +29,15 @@ build_flags = ${common.build_flags}
 lib_deps =
   ${common.lib_deps}
 
+[env:nodemcu]
+platform = ${common.platform}
+framework = ${common.framework}
+board = nodemcu
+upload_speed = 115200
+build_flags = ${common.build_flags}
+lib_deps =
+  ${common.lib_deps}
+
 [env:nodemcuv2]
 platform = ${common.platform}
 framework = ${common.framework}


### PR DESCRIPTION
Hey
thanks for the great work
I have a nodemcu0.9 Development Board in my MQTT433gateway at home, which had run on the arduino branch until today. I looked up the platformio-board-alias on http://platformio.org/boards. The Configuration Change in this commit was tested from a windows machine via USB connection and via OTA (for which I clarified the python version in README.md).

Worked without further adoption (as soon as I stopped mistyping my WiFi Password ;-) )